### PR TITLE
Use getter.ToRESTConfig() instead of factory.ToRawKubeConfigLoader()

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -70,7 +70,7 @@ func (c *Configuration) Init(getter genericclioptions.RESTClientGetter, namespac
 		namespace: namespace,
 		kcFn:      factory.KubernetesClientSet,
 		kbFn: func() (client.Client, error) {
-			config, err := factory.ToRawKubeConfigLoader().ClientConfig()
+			config, err := getter.ToRESTConfig()
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -271,7 +271,7 @@ func (c *Client) checkStatusExceptJobs(resources kube.ResourceList, timeout time
 		return fmt.Errorf("c.Client.Factory is not a cmdutil.Factory")
 	}
 
-	cfg, err := factory.ToRawKubeConfigLoader().ClientConfig()
+	cfg, err := factory.ToRESTConfig()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`ToRawKubeConfigLoader()` method isn't compatible with private cluster config