### PR TITLE
Default to the "default" variant when none is requested

### DIFF
--- a/pkg/values/preset.go
+++ b/pkg/values/preset.go
@@ -16,34 +16,45 @@ import (
 	chartsapi "x-helm.dev/apimachinery/apis/charts/v1alpha1"
 )
 
-func LoadPresetValues(kc client.Client, ref chartsapi.ChartPresetFlatRef) ([]chartsapi.ChartPresetValues, error) {
-	if ref.Variant == "" {
-		// required for editor charts
-		return nil, nil
-	}
+const defaultVariant = "default"
 
-	rid := &kmapi.ResourceID{
+func LoadPresetValues(kc client.Client, ref chartsapi.ChartPresetFlatRef) ([]chartsapi.ChartPresetValues, error) {
+	in := kmapi.ResourceID{
 		Group: ref.Group,
 		Name:  ref.Resource,
 		Kind:  ref.Kind,
 	}
-	rid, err := kmapi.ExtractResourceID(kc.RESTMapper(), *rid)
+	rid, err := kmapi.ExtractResourceID(kc.RESTMapper(), in)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to detect resource ID for %#v", *rid)
+		if ref.Variant == "" {
+			return nil, nil
+		}
+		return nil, errors.Wrapf(err, "failed to detect resource ID for %#v", in)
 	}
 	ed, err := resourceeditors.LoadByGVR(kc, rid.GroupVersionResource())
 	if err != nil {
+		if ref.Variant == "" {
+			return nil, nil
+		}
 		return nil, err
 	}
 
+	variantName := ref.Variant
+	if variantName == "" {
+		variantName = defaultVariant
+	}
 	var variant *uiapi.VariantRef
 	for i := range ed.Spec.Variants {
-		if ed.Spec.Variants[i].Name == ref.Variant {
+		if ed.Spec.Variants[i].Name == variantName {
 			variant = &ed.Spec.Variants[i]
 			break
 		}
 	}
 	if variant == nil {
+		if ref.Variant == "" {
+			// editor either declares no variants or none named defaultVariant, so the caller must pick one
+			return nil, nil
+		}
 		return nil, errors.Errorf("No variant with name %s found for %+v", ref.Variant, *rid)
 	}
 


### PR DESCRIPTION
ChartPreset values were silently missing from editor `/values` responses for every KubeDB editor: `machineProfiles` is present in `clusterchartpresets/kubedb-ui-presets`, but the API returned bare chart defaults.

Cause: `LoadPresetValues` returns `nil, nil` when `ref.Variant == ""`, and b3 (the only `/values` server) never sets it — it comes purely from the caller query string, so the UI got zero presets with HTTP 200 and no error anywhere.

Fix: resolve the editor first, then fall back to the variant named `default` when the caller did not request one. An unconditional default would regress other editors, so the lenient `nil, nil` is retained for an unset variant whenever the GVR, the ResourceEditor, or the variant itself cannot be resolved. Of the 45 hub resourceeditors that declare `variants:`, all use `default` except `rds.aws.kubedb.com/v1alpha1/clusters` (`MariaDB`/`MySQL`/`PostgreSQL`); that one and editors with no variants at all (e.g. `ui.k8s.appscode.com/v1alpha1/featuresets`) keep their current behavior instead of starting to 500. An explicitly requested variant that does not exist still errors as before.

Also fixes a nil deref: the `ExtractResourceID` error path formatted `*rid` after `rid` had been reassigned to `nil`, panicking the aggregated apiserver (observed as ~200 restarts of `kube-ui-server`, `LoadPresetValues` at the old `preset.go:32`). It now formats the pre-call value.

`go build ./...`, `gofmt -l`, and `go vet ./pkg/values/` are clean.